### PR TITLE
pass GID and UID in build args (#4)

### DIFF
--- a/Docker/vxbuild/Dockerfile
+++ b/Docker/vxbuild/Dockerfile
@@ -8,10 +8,13 @@ RUN dpkg --add-architecture i386 && \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV GID 1000
+ARG UID=1000
+ARG GID=1000
+
+ENV GID ${GID}
 ENV GROUP wruser
 ENV INSTALL_DIR /opt/windriver
-ENV UID 1000
+ENV UID ${UID}
 ENV USER wruser
 ENV HOME /home/${USER}
 ENV WRENV vxworks-7

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cd vxworks7-ros2-build
 Build Docker image
 ```
 cd Docker/vxbuild
-docker build -t vxbuild:1.0 .
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t vxbuild:1.0 .
 cd Docker/vxros2build
 docker build -t vxros2build:1.0 .
 ```


### PR DESCRIPTION
connect to #4 
Pass build args : UID and GID when build vxbuild image. This will keep the same UID and GID with host environment and container. 
Signed-off-by: YuSheng <chester@cwyark.me>