### PR TITLE
sync with dashing-release-SR0640

### DIFF
--- a/.github/workflows/mirror-master-to-dashing.yaml
+++ b/.github/workflows/mirror-master-to-dashing.yaml
@@ -1,4 +1,4 @@
-name: Mirror master to dashing-release-SR0640-python
+name: Mirror master to dashing-release-SR0640
 
 on:
   push:
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: zofrex/mirror-branch@v1
       with:
-        target-branch: dashing-release-SR0640-python
+        target-branch: dashing-release-SR0640

--- a/.github/workflows/vxworks-ros2-build.yml
+++ b/.github/workflows/vxworks-ros2-build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        branch: [dashing-release-SR0640-python]
+        branch: [dashing-release-SR0640]
         sdk: [wrsdk-vxworks7-up2-1.7, wrsdk-vxworks7-raspberrypi4b-1.0]
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
There are two identical branches: `dashing-release-SR0640` and `dashing-release-SR0640-python`, let us use the first one