### PR TITLE
fix pybind11_vendor and pyyaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 ifeq ($(ROS_DISTRO),dashing)
 DEFAULT_BUILD ?= sdk unixextra asio tinyxml2 colcon ros2 turtlebot3
 else
-DEFAULT_BUILD ?= sdk unixextra asio tinyxml2 colcon ros2
+DEFAULT_BUILD ?= sdk unixextra asio tinyxml2 colcon ros2 pyyaml
 endif
 endif
 

--- a/pkg/pyyaml/Makefile
+++ b/pkg/pyyaml/Makefile
@@ -1,0 +1,45 @@
+# Makefile - for pyyaml
+#
+# Copyright (c) 2023 Wind River Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include $(WIND_USR_MK)/defs.common.mk
+include $(WIND_USR_MK)/defs.packages.mk
+include $(WIND_USR_MK)/defs.crossbuild.mk
+
+PKG_NAME = pyyaml
+PACKAGES += $(PKG_NAME)
+
+PKG_VER = 6.0.1
+PKG_FILE_NAME = $(PKG_VER).tar.gz
+
+PKG_URL = https://github.com/yaml/pyyaml/archive/refs/tags/$(PKG_FILE_NAME)
+PKG_TYPE = unpack
+
+PKG_LICENSE = MIT
+
+PKG_PATCH_DIR = files
+PKG_BUILD_DIR = ${PKG_NAME}-$(PKG_VER)
+PKG_SRC_DIR = ${PKG_NAME}-$(PKG_VER)
+
+PKG_MAKE_BUILD_VAR = PYTHON=python3.$(TGT_PYTHON_MINOR) \
+		     CC=wr-cc \
+		     CFLAGS="-I $(WIND_CC_SYSROOT)/usr/3pp/develop/usr/include/python3.$(TGT_PYTHON_MINOR) -I $(ROOT_DIR)/include/libyaml_vendor" \
+		     LDSHARED="wr-cc -shared" \
+		     LDFLAGS="-L $(WIND_CC_SYSROOT)/usr/3pp/develop/usr/lib -lpython3 -L $(ROOT_DIR)/lib -lyaml"
+PKG_MAKE_INSTALL_OPT = install PARAMETERS=--prefix=$(ROOT_DIR) \
+		       && rm -rf $(ROOT_DIR)/lib/python3.$(TGT_PYTHON_MINOR)/site-packages/PyYAML-$(PKG_VER)-py3.$(TGT_PYTHON_MINOR).egg-info \
+		       && mv -f $(ROOT_DIR)/lib/python3.$(TGT_PYTHON_MINOR)/site-packages/PyYAML-$(PKG_VER)-py3.$(TGT_PYTHON_MINOR)-linux-x86_64.egg/ $(ROOT_DIR)/lib/python3.$(TGT_PYTHON_MINOR)/site-packages/PyYAML-$(PKG_VER)-py3.$(TGT_PYTHON_MINOR).egg-info \
+		       && cp -r $(ROOT_DIR)/lib/python3.$(TGT_PYTHON_MINOR)/site-packages/PyYAML-$(PKG_VER)-py3.$(TGT_PYTHON_MINOR).egg-info $(DEPLOY_DIR)/lib/python3.$(TGT_PYTHON_MINOR)/site-packages/. 
+include $(WIND_USR_MK)/rules.packages.mk

--- a/pkg/pyyaml/README.md
+++ b/pkg/pyyaml/README.md
@@ -1,0 +1,10 @@
+# `pyyaml`
+
+We can not install `pyyaml` with `pip` as we do for other packages
+
+```bash
+pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) pyyaml
+``` 
+
+It will install a precompiled extension for Linux and we need one for VxWorks.
+Let us build it ourselves. 

--- a/pkg/pyyaml/files/0001-pyyaml.patch
+++ b/pkg/pyyaml/files/0001-pyyaml.patch
@@ -1,0 +1,29 @@
+diff --git a/Makefile b/Makefile
+index 34a1d40..b745d73 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ 
+ .PHONY: build dist
+ 
+-PYTHON=/usr/bin/python3
++PYTHON?=python3.9
+ TEST=
+ PARAMETERS=
+ 
+diff --git a/setup.py b/setup.py
+index 944e7fa..03d3116 100644
+--- a/setup.py
++++ b/setup.py
+@@ -75,6 +75,11 @@ from setuptools.command.build_ext import build_ext as _build_ext
+ # NB: distutils imports must remain below setuptools to ensure we use the embedded version
+ from distutils import log
+ from distutils.errors import DistutilsError, CompileError, LinkError, DistutilsPlatformError
++from distutils import sysconfig
++
++sysconfig._config_vars['EXT_SUFFIX'] = '.cpython-39-vxworks.so'
++sysconfig._config_vars['SOABI'] = 'cpython-39-vxworks'
++sysconfig._config_vars['SO'] = '.cpython-39-vxworks.so'
+ 
+ with_cython = False
+ if 'sdist' in sys.argv or os.environ.get('PYYAML_FORCE_CYTHON') == '1':

--- a/pkg/pyyaml/files/series
+++ b/pkg/pyyaml/files/series
@@ -1,0 +1,1 @@
+0001-pyyaml.patch

--- a/pkg/ros2/Makefile
+++ b/pkg/ros2/Makefile
@@ -105,7 +105,6 @@ ros2.install : ros2.build
 	@$(call echo_action,Installing runtime dependencies,$*)
 	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) setuptools
 	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) catkin_pkg
-	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) pyyaml
 	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) empy
 	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) pyelftools
 	pip3 install --ignore-installed --prefix=$(DEPLOY_DIR) packaging

--- a/pkg/ros2/files/humble/packages.mk
+++ b/pkg/ros2/files/humble/packages.mk
@@ -25,6 +25,7 @@ ROS2_PATCH_DIRS=eclipse-iceoryx/iceoryx \
                 eclipse-cyclonedds/cyclonedds \
                 eProsima/Fast-DDS \
                 eProsima/foonathan_memory_vendor \
+		ros2/pybind11_vendor \
 		ros2/ros2_tracing \
                 ros2/rmw_implementation \
                 ros2/rclcpp \


### PR DESCRIPTION
- `rclpy` produces `_rclpy_pybind11.cpython-39-x86_64-linux-gnu.so` - a native Linux library, because `pybind11` does not handle properly python extensions. We fix it.
-  we cannot install `pyyaml` with `pip`, it will install `_yaml.cpython-39-x86_64-linux-gnu.so`. We'll build it for VxWorks