### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The 23.03 SDK for IA - QEMU x86_64 shall be used from https://forums.windriver.c
 cd ~/Downloads 
 wget https://d13321s3lxgewa.cloudfront.net/wrsdk-vxworks7-qemu-1.12.1.tar.bz2
 mkdir ~/Downloads/wrsdk && cd ~/Downloads/wrsdk
-tar -jxvf ~/Downloads/wrsdk-vxworks7-qemu-1.12.tar.bz2 --strip 1
+tar -jxvf ~/Downloads/wrsdk-vxworks7-qemu-1.12.1.tar.bz2 --strip 1
 ```
 
 ### Run Docker image


### PR DESCRIPTION
Following instruction has been fixed:

instead:
`tar -jxvf ~/Downloads/wrsdk-vxworks7-qemu-1.12.tar.bz2 --strip 1`

should be:
`tar -jxvf ~/Downloads/wrsdk-vxworks7-qemu-1.12.1.tar.bz2 --strip 1`